### PR TITLE
Include link to page's Git source at bottom of page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ description: Fosstodon Hub is an informational site tied to Fosstodon, the large
 lang: en
 locale: en_GB
 url: "https://hub.fosstodon.org"
+git_web_base: https://github.com/fosstodon/hub/blob/HEAD/
 baseurl: ""
 permalink: :title
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,10 @@
     <footer>
       <p>The Fosstodon Hub was <code>&lt;/&gt;</code> with ♥ using <a href="https://jekyllrb.com">Jekyll</a> and <a href="https://simplecss.org">Simple.css</a>.</p>
 
-      <p><a href="/feed.xml"><svg class="icon" aria-hidden="true" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M4.259 23.467c-2.35 0-4.259 1.917-4.259 4.252 0 2.349 1.909 4.244 4.259 4.244 2.358 0 4.265-1.895 4.265-4.244-0-2.336-1.907-4.252-4.265-4.252zM0.005 10.873v6.133c3.993 0 7.749 1.562 10.577 4.391 2.825 2.822 4.384 6.595 4.384 10.603h6.16c-0-11.651-9.478-21.127-21.121-21.127zM0.012 0v6.136c14.243 0 25.836 11.604 25.836 25.864h6.152c0-17.64-14.352-32-31.988-32z"></path></svg> RSS Feed</a></p>
+      <p>
+        <a href="/feed.xml"><svg class="icon" aria-hidden="true" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M4.259 23.467c-2.35 0-4.259 1.917-4.259 4.252 0 2.349 1.909 4.244 4.259 4.244 2.358 0 4.265-1.895 4.265-4.244-0-2.336-1.907-4.252-4.265-4.252zM0.005 10.873v6.133c3.993 0 7.749 1.562 10.577 4.391 2.825 2.822 4.384 6.595 4.384 10.603h6.16c-0-11.651-9.478-21.127-21.121-21.127zM0.012 0v6.136c14.243 0 25.836 11.604 25.836 25.864h6.152c0-17.64-14.352-32-31.988-32z"></path></svg> RSS Feed</a>
+        {% if site.git_web_base %}• <a href="{{ site.git_web_base }}{{ page.path }}">Git source</a>{% endif %}
+      </p>
     </footer>
 
   </body>


### PR DESCRIPTION
From the footer, I saw that https://hub.fosstodon.org/ was a Jekyll site, and wondered if the source was available. I did eventually find this repository, but in a roundabout way.

This PR adds a link to the Git source -- in fact, a direct link to the page's source, no matter if it's a page or a post.  For an example, take a look at the very bottom of https://blog.finnix.org/2022/03/22/finnix-124-released/ , a Jekyll site of mine.  Thanks!