### PR TITLE
Post attribution

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -8,13 +8,17 @@ mike:
   url: https://fosstodon.org/@mike
 gina:
   name: Gina
-  email: mail@fosstodon.org
+  email: gina@fosstodon.org
   url: https://fosstodon.org/@gina
 brandon:
   name: Brandon
-  email: mail@fosstodon.org
+  email: btp@fosstodon.org
   url: https://fosstodon.org/@btp
 kris:
   name: Kris
-  email: mail@fosstodon.org
+  email: kris@fosstodon.org
   url: https://fosstodon.org/@krisfreedain
+fosstodon:
+  name: The Fosstodon Team
+  email: mail@fosstodon.org
+  url: https://fosstodon.org/@fosstodon

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,7 @@ layout: default
 <!-- Insert author details -->
 {% assign author = site.data.authors[page.author] %}
 {% if author %}
+    <meta name="fediverse:creator" content="{{ author.url }}">
     <p class="post-meta">Written by: <a target="blank" href="{{ author.url }}">{{ author.name }}</a> &nbsp;|&nbsp; {{ page.date | date_to_string }}</p>
 {% endif %}
 


### PR DESCRIPTION
Added the meta tag for url card author attribution to the posts layout. Also updated the new admin's emails in `authors.yml` and created a generic `The Fosstodon Team` author.

Additionally, the Fosstodon authors will also need to place `hub.fosstodon.org` in their `Websites allowed to credit you` section of the `Verification` page in their Fosstodon accounts to allow the attribution to work.